### PR TITLE
refactor: 회원 가입 API 수정

### DIFF
--- a/src/main/java/com/example/qnacomunity/config/SecurityConfig.java
+++ b/src/main/java/com/example/qnacomunity/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.example.qnacomunity.config;
 
 import com.example.qnacomunity.security.JwtFilter;
-import com.example.qnacomunity.security.JwtUtil;
+import com.example.qnacomunity.security.JwtProvider;
 import com.example.qnacomunity.security.MemberDetailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -19,7 +19,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-  private final JwtUtil jwtUtil;
+  private final JwtProvider jwtProvider;
   private final MemberDetailService memberDetailService;
 
   @Bean
@@ -28,17 +28,17 @@ public class SecurityConfig {
     http //page 부분은 프론트 에서 구현
         .authorizeHttpRequests((auth) -> auth
             .requestMatchers(AntPathRequestMatcher.antMatcher("/page/home")).permitAll()
-            .requestMatchers(AntPathRequestMatcher.antMatcher("/page/sign-in")).permitAll()
-            .requestMatchers(AntPathRequestMatcher.antMatcher("/page/sign-up")).permitAll()
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/page/registration")).permitAll()
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/page/login")).permitAll()
             .requestMatchers(AntPathRequestMatcher.antMatcher("/page/logout")).permitAll()
-            .requestMatchers(AntPathRequestMatcher.antMatcher("/member/sign-in")).permitAll()
-            .requestMatchers(AntPathRequestMatcher.antMatcher("/member/sign-up")).permitAll()
-            .requestMatchers(AntPathRequestMatcher.antMatcher("/member/get-role")).permitAll()
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/member/registration")).permitAll()
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/member/login")).permitAll()
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/member/role")).permitAll()
             .anyRequest().authenticated()
         );
 
     http //JWT 토큰 확인 필터를 UsernamePasswordAuthenticationFilter 보다 앞에 위치
-        .addFilterBefore(new JwtFilter(jwtUtil, memberDetailService),
+        .addFilterBefore(new JwtFilter(jwtProvider, memberDetailService),
             UsernamePasswordAuthenticationFilter.class);
 
     http //로그아웃
@@ -52,9 +52,9 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable);
 
     http //oauth 구글 로그인
-        .oauth2Login((auth) -> auth.loginPage("/page/sign-in")
+        .oauth2Login((auth) -> auth.loginPage("/page/login")
             .defaultSuccessUrl("/page/home")
-            .failureUrl("/page/sign-in")
+            .failureUrl("/page/login")
             .permitAll());
 
     return http.build();

--- a/src/main/java/com/example/qnacomunity/dto/form/MemberForm.java
+++ b/src/main/java/com/example/qnacomunity/dto/form/MemberForm.java
@@ -20,7 +20,7 @@ public class MemberForm {
     private String password;
 
     @NotBlank(message = "비밀번호 확인을 입력해주세요.")
-    private String passCheck;
+    private String passwordCheck;
 
     @Size(min = 2, max = 10, message = "양식 오류: 닉네임을 2~10자 사이로 입력해주세요.")
     private String nickName;
@@ -42,16 +42,16 @@ public class MemberForm {
 
   @Getter
   @Builder
-  public static class PassChangeForm {
+  public static class PasswordChangeForm {
 
     @NotBlank(message = "이전 비밀번호를 입력해주세요.")
-    private String oldPass;
+    private String oldPassword;
 
     @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z]).{8,20}$", message = "양식 오류: 소문자,대문자,숫자를 포함한 8~20자의 비밀번호를 입력해주세요.")
-    private String newPass;
+    private String newPassword;
 
     @NotBlank(message = "비밀번호 확인을 입력해주세요.")
-    private String newPassCheck;
+    private String newPasswordCheck;
   }
 
   @Getter

--- a/src/main/java/com/example/qnacomunity/dto/response/MemberResponse.java
+++ b/src/main/java/com/example/qnacomunity/dto/response/MemberResponse.java
@@ -1,6 +1,7 @@
 package com.example.qnacomunity.dto.response;
 
 import com.example.qnacomunity.entity.Member;
+import com.example.qnacomunity.type.Role;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,9 +17,11 @@ import lombok.Setter;
 public class MemberResponse {
 
   private Long id;
+  private String loginId;
+  private String password;
   private String nickName;
   private String email;
-  private String role;
+  private Role role;
   private int score;
   private String profileUrl;
   private LocalDateTime createdAt;

--- a/src/main/java/com/example/qnacomunity/entity/Member.java
+++ b/src/main/java/com/example/qnacomunity/entity/Member.java
@@ -1,6 +1,9 @@
 package com.example.qnacomunity.entity;
 
+import com.example.qnacomunity.type.Role;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -28,7 +31,10 @@ public class Member {
   private String password;
   private String nickName;
   private String email;
-  private String role;
+
+  @Enumerated(EnumType.STRING)
+  private Role role;
+
   private String profileUrl;
   private int score;
 

--- a/src/main/java/com/example/qnacomunity/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/qnacomunity/exception/CustomExceptionHandler.java
@@ -14,4 +14,10 @@ public class CustomExceptionHandler {
     log.warn("커스텀 에러 발생: {}", e.getMessage());
     return ResponseEntity.badRequest().body(e.getMessage());
   }
+
+  @ExceptionHandler(FormException.class)
+  public ResponseEntity<String> formExceptionHandler(final FormException e) {
+    log.warn("양식 에러 발생: {}", e.getMessage());
+    return ResponseEntity.badRequest().body(e.getMessage());
+  }
 }

--- a/src/main/java/com/example/qnacomunity/exception/FormException.java
+++ b/src/main/java/com/example/qnacomunity/exception/FormException.java
@@ -1,0 +1,14 @@
+package com.example.qnacomunity.exception;
+
+import lombok.Getter;
+
+@Getter
+public class FormException extends RuntimeException {
+
+  private final String message;
+
+  public FormException(String message) {
+    super(message);
+    this.message = message;
+  }
+}

--- a/src/main/java/com/example/qnacomunity/repository/MemberRepository.java
+++ b/src/main/java/com/example/qnacomunity/repository/MemberRepository.java
@@ -9,8 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-  Optional<Member> findByLoginId(String loginId);
-
   Optional<Member> findByLoginIdAndDeletedAtIsNull(String loginId);
 
 }

--- a/src/main/java/com/example/qnacomunity/security/CustomUserDetail.java
+++ b/src/main/java/com/example/qnacomunity/security/CustomUserDetail.java
@@ -1,9 +1,9 @@
 package com.example.qnacomunity.security;
 
-import com.example.qnacomunity.entity.Member;
+import com.example.qnacomunity.dto.response.MemberResponse;
 import org.springframework.security.core.userdetails.UserDetails;
 
 public interface CustomUserDetail extends UserDetails {
 
-  Member getMember();
+  MemberResponse getMemberResponse();
 }

--- a/src/main/java/com/example/qnacomunity/security/JwtFilter.java
+++ b/src/main/java/com/example/qnacomunity/security/JwtFilter.java
@@ -16,7 +16,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-  private final JwtUtil jwtUtil;
+  private final JwtProvider jwtProvider;
   private final MemberDetailService memberDetailService;
 
   @Override
@@ -28,9 +28,9 @@ public class JwtFilter extends OncePerRequestFilter {
     String token = request.getHeader("TOKEN");
 
     //토큰이 존재하고 파싱 가능할 때 Authentication 생성,저장
-    if (token != null && jwtUtil.getLoginId(token) != null) {
+    if (token != null && jwtProvider.getLoginId(token) != null) {
 
-      String loginId = jwtUtil.getLoginId(token);
+      String loginId = jwtProvider.getLoginId(token);
       CustomUserDetail userDetails = memberDetailService.loadUserByUsername(loginId);
 
       Authentication auth =

--- a/src/main/java/com/example/qnacomunity/security/JwtProvider.java
+++ b/src/main/java/com/example/qnacomunity/security/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.example.qnacomunity.security;
 
+import com.example.qnacomunity.type.Role;
 import io.jsonwebtoken.Jwts;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -9,22 +10,23 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
-public class JwtUtil {
+public class JwtProvider {
 
   private final SecretKey secretKey;
+  private static final long EXPIRE_TIME = 1000 * 60 * 60 * 24;
 
-  public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
+  public JwtProvider(@Value("${spring.jwt.secret}") String secret) {
     this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
         Jwts.SIG.HS256.key().build().getAlgorithm());
   }
 
   //토큰 생성
-  public String createToken(String loginId, String role) {
+  public String createToken(String loginId, Role role) {
     return Jwts.builder()
         .claim("loginId", loginId)
         .claim("role", role)
         .issuedAt(new Date())
-        .expiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24))
+        .expiration(new Date(System.currentTimeMillis() + EXPIRE_TIME))
         .signWith(secretKey)
         .compact();
   }

--- a/src/main/java/com/example/qnacomunity/security/MemberDetail.java
+++ b/src/main/java/com/example/qnacomunity/security/MemberDetail.java
@@ -1,5 +1,6 @@
 package com.example.qnacomunity.security;
 
+import com.example.qnacomunity.dto.response.MemberResponse;
 import com.example.qnacomunity.entity.Member;
 import java.util.Collection;
 import java.util.List;
@@ -10,29 +11,29 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 @Data
 public class MemberDetail implements CustomUserDetail {
 
-  private final Member member;
+  private final MemberResponse memberResponse;
 
   @Override
   public String getUsername() {
-    return member.getLoginId();
+    return memberResponse.getLoginId();
   }
 
   @Override
   public String getPassword() {
-    return member.getPassword();
+    return memberResponse.getPassword();
   }
 
   public String getName() {
-    return member.getNickName();
+    return memberResponse.getNickName();
   }
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return List.of(new SimpleGrantedAuthority(member.getRole()));
+    return List.of(new SimpleGrantedAuthority(memberResponse.getRole().toString()));
   }
 
   @Override
-  public Member getMember() {
-    return member;
+  public MemberResponse getMemberResponse() {
+    return memberResponse;
   }
 }

--- a/src/main/java/com/example/qnacomunity/security/MemberDetailService.java
+++ b/src/main/java/com/example/qnacomunity/security/MemberDetailService.java
@@ -1,5 +1,6 @@
 package com.example.qnacomunity.security;
 
+import com.example.qnacomunity.dto.response.MemberResponse;
 import com.example.qnacomunity.entity.Member;
 import com.example.qnacomunity.exception.CustomException;
 import com.example.qnacomunity.exception.ErrorCode;
@@ -19,6 +20,6 @@ public class MemberDetailService implements UserDetailsService {
     Member member = memberRepository.findByLoginIdAndDeletedAtIsNull(loginId)
         .orElseThrow(() -> new CustomException(ErrorCode.ID_NOT_FOUND));
 
-    return new MemberDetail(member);
+    return new MemberDetail(MemberResponse.from(member));
   }
 }

--- a/src/main/java/com/example/qnacomunity/security/Oauth2UserDetail.java
+++ b/src/main/java/com/example/qnacomunity/security/Oauth2UserDetail.java
@@ -1,5 +1,6 @@
 package com.example.qnacomunity.security;
 
+import com.example.qnacomunity.dto.response.MemberResponse;
 import com.example.qnacomunity.entity.Member;
 import java.util.Collection;
 import java.util.List;
@@ -13,26 +14,26 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 public class Oauth2UserDetail implements CustomUserDetail, OAuth2User {
 
   private final Map<String, Object> attributes;
-  private final Member member;
+  private final MemberResponse memberResponse;
 
   @Override
   public String getUsername() {
-    return member.getLoginId();
+    return memberResponse.getLoginId();
   }
 
   @Override
   public String getPassword() {
-    return member.getPassword();
+    return memberResponse.getPassword();
   }
 
   @Override
   public String getName() {
-    return member.getNickName();
+    return memberResponse.getNickName();
   }
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return List.of(new SimpleGrantedAuthority(member.getRole()));
+    return List.of(new SimpleGrantedAuthority(memberResponse.getRole().toString()));
   }
 
   @Override
@@ -41,7 +42,7 @@ public class Oauth2UserDetail implements CustomUserDetail, OAuth2User {
   }
 
   @Override
-  public Member getMember() {
-    return member;
+  public MemberResponse getMemberResponse() {
+    return memberResponse;
   }
 }

--- a/src/main/java/com/example/qnacomunity/security/Oauth2UserService.java
+++ b/src/main/java/com/example/qnacomunity/security/Oauth2UserService.java
@@ -1,5 +1,6 @@
 package com.example.qnacomunity.security;
 
+import com.example.qnacomunity.dto.response.MemberResponse;
 import com.example.qnacomunity.entity.Member;
 import com.example.qnacomunity.repository.MemberRepository;
 import com.example.qnacomunity.service.MemberService;
@@ -46,10 +47,10 @@ public class Oauth2UserService extends DefaultOAuth2UserService {
       member = memberRepository.save(member);
 
       //새로 가입된 회원 UserDetail 반환
-      return new Oauth2UserDetail(atr, member);
+      return new Oauth2UserDetail(atr, MemberResponse.from(member));
     }
 
     //회원 정보가 있으면 해당 회원 UserDetail 반환
-    return new Oauth2UserDetail(atr, optionalMember.get());
+    return new Oauth2UserDetail(atr, MemberResponse.from(optionalMember.get()));
   }
 }

--- a/src/main/java/com/example/qnacomunity/type/Role.java
+++ b/src/main/java/com/example/qnacomunity/type/Role.java
@@ -1,0 +1,5 @@
+package com.example.qnacomunity.type;
+
+public enum Role {
+  ROLE_USER, ROLE_MANAGER
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- MemberController: API path 수정
- CustomUserDetail: Member(entity) 대신 MemberResponse(dto) 사용
- MemberService: getMember() 생성(MemberResponse -> Member 변환) 
- MemberService: getInfo() -> 삭제, MemberController 에서 dto 바로 반환
- Role.enum 생성
- Member: role 타입 String -> Role 변경
- JwtProvider: 토큰 만료 시간(1000 * 60 * 60 * 24) -> 상수(EXPIRE_TIME) 변경
- MemberForm: 약어(pass) -> 풀네임(password) 변경
- MemberService: 회원가입 시 Member entity 에 '프로필 사진 URL' 세팅 삭제
- MemberService: 회원탈퇴 시 loginId 변경 삭제
- MemberService: 탈퇴회원 loginId 재사용 위해 아이디 중복 체크시 findByLogin -> findByLoginIdAndDeletedAtIsNull
- FormException(Valid error) 생성, Exception Handler 적용
- MemberController: Valid error 시 return badRequest -> throw FormException
- JwtUtil.class -> JwtProvider.class 이름 변경

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 