### PR TITLE
feat: 멤버 스코어 기능 구현

### DIFF
--- a/src/main/java/com/example/qnacomunity/aop/LockService.java
+++ b/src/main/java/com/example/qnacomunity/aop/LockService.java
@@ -1,0 +1,30 @@
+package com.example.qnacomunity.aop;
+
+import com.example.qnacomunity.entity.Member;
+import com.example.qnacomunity.entity.Question;
+import com.example.qnacomunity.type.ScoreDescription;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LockService {
+  private final MemberScoreService memberScoreService;
+  private final QuestionHitService questionHitService;
+
+  @ScoreLock
+  public Member changeScore(
+      Long memberId, int score, ScoreDescription description, Question relatedQuestion
+  ) {
+
+    //락 획득 후 내부의 트랜잭션 메서드로 진행
+    return memberScoreService.change(memberId, score, description, relatedQuestion);
+    //트랜잭션 종료되며 커밋 실행 -> 락 해제 -> 다음 락 획득자가 이전 변경 사항을 읽어 올 수 있다
+  }
+
+  @HitsLock
+  public Question increaseHits(Long questionId) {
+
+    return questionHitService.increase(questionId);
+  }
+}

--- a/src/main/java/com/example/qnacomunity/aop/MemberScoreService.java
+++ b/src/main/java/com/example/qnacomunity/aop/MemberScoreService.java
@@ -1,0 +1,51 @@
+package com.example.qnacomunity.aop;
+
+import com.example.qnacomunity.entity.Member;
+import com.example.qnacomunity.entity.Question;
+import com.example.qnacomunity.entity.ScoreHistory;
+import com.example.qnacomunity.exception.CustomException;
+import com.example.qnacomunity.exception.ErrorCode;
+import com.example.qnacomunity.repository.MemberRepository;
+import com.example.qnacomunity.repository.ScoreHistoryRepository;
+import com.example.qnacomunity.type.ScoreDescription;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberScoreService {
+
+  private final MemberRepository memberRepository;
+  private final ScoreHistoryRepository scoreHistoryRepository;
+
+  //락 획득 후 진행
+  @Transactional
+  public Member change(Long memberId, int score, ScoreDescription description, Question relatedQuestion) {
+
+    Member member =  memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+    //변경 전 스코어
+    int previous = member.getScore();
+
+    //변경 후 스코어
+    int remain = member.getScore() + score;
+
+    //멤버의 스코어 변경
+    member.setScore(remain);
+    memberRepository.save(member);
+
+    //스코어 히스토리에 기록
+    scoreHistoryRepository.save(ScoreHistory.builder()
+        .member(member)
+        .score(score)
+        .previous(previous)
+        .remain(remain)
+        .description(description) //변경 사유
+        .relatedQuestion(relatedQuestion) //연관 질문(null 가능)
+        .build());
+
+    return member;
+  }
+}

--- a/src/main/java/com/example/qnacomunity/aop/QuestionHitService.java
+++ b/src/main/java/com/example/qnacomunity/aop/QuestionHitService.java
@@ -6,14 +6,15 @@ import com.example.qnacomunity.exception.ErrorCode;
 import com.example.qnacomunity.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class QuestionHitService {
   private final QuestionRepository questionRepository;
 
-  @HitsLock
-  public Question increaseHits(Long questionId) {
+  @Transactional
+  public Question increase(Long questionId) {
 
     Question question = questionRepository.findById(questionId)
         .orElseThrow(() -> new CustomException(ErrorCode.Q_NOT_FOUND));

--- a/src/main/java/com/example/qnacomunity/aop/ScoreLock.java
+++ b/src/main/java/com/example/qnacomunity/aop/ScoreLock.java
@@ -1,0 +1,16 @@
+package com.example.qnacomunity.aop;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface ScoreLock {
+
+}

--- a/src/main/java/com/example/qnacomunity/controller/MemberController.java
+++ b/src/main/java/com/example/qnacomunity/controller/MemberController.java
@@ -2,6 +2,8 @@ package com.example.qnacomunity.controller;
 
 import com.example.qnacomunity.dto.form.MemberForm;
 import com.example.qnacomunity.dto.response.MemberResponse;
+import com.example.qnacomunity.dto.response.ScoreHistoryResponse;
+import com.example.qnacomunity.repository.ScoreHistoryRepository;
 import com.example.qnacomunity.security.CustomUserDetail;
 import com.example.qnacomunity.service.MemberService;
 import com.example.qnacomunity.type.Role;
@@ -9,6 +11,10 @@ import jakarta.validation.Valid;
 import java.io.IOException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,6 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberController {
 
   private final MemberService memberService;
+  private final ScoreHistoryRepository scoreHistoryRepository;
 
   //회원 가입
   @PostMapping("/registration")
@@ -105,5 +112,18 @@ public class MemberController {
   public ResponseEntity<String> delete(@AuthenticationPrincipal CustomUserDetail userDetail) {
     memberService.delete(userDetail.getMemberResponse());
     return ResponseEntity.ok("회원 탈퇴 완료");
+  }
+
+  //스코어 히스토리 확인
+  @GetMapping("/score-histories")
+  public ResponseEntity<Page<ScoreHistoryResponse>> getScoreHistories(
+      @AuthenticationPrincipal CustomUserDetail userDetail,
+      @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+  ) {
+
+    return ResponseEntity.ok(
+        scoreHistoryRepository.findAllByMember_Id(userDetail.getMemberResponse().getId(), pageable)
+            .map(ScoreHistoryResponse::from)
+    );
   }
 }

--- a/src/main/java/com/example/qnacomunity/dto/response/ScoreHistoryResponse.java
+++ b/src/main/java/com/example/qnacomunity/dto/response/ScoreHistoryResponse.java
@@ -1,0 +1,46 @@
+package com.example.qnacomunity.dto.response;
+
+import com.example.qnacomunity.entity.ScoreHistory;
+import com.example.qnacomunity.type.ScoreDescription;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ScoreHistoryResponse {
+
+  private Long id;
+  private Long memberId;
+  private String memberNickName;
+  private int score;
+  private int previous;
+  private int remain;
+  private ScoreDescription description;
+  private Long questionId;
+  private String questionTitle;
+  private LocalDateTime createdAt;
+
+  public static ScoreHistoryResponse from(ScoreHistory scoreHistory) {
+    return ScoreHistoryResponse.builder()
+        .id(scoreHistory.getId())
+        .memberId(scoreHistory.getMember().getId())
+        .memberNickName(scoreHistory.getMember().getNickName())
+        .score(scoreHistory.getScore())
+        .previous(scoreHistory.getPrevious())
+        .remain(scoreHistory.getRemain())
+        .description(scoreHistory.getDescription())
+        .questionId(scoreHistory.getRelatedQuestion() == null ?
+            null : scoreHistory.getRelatedQuestion().getId())
+        .questionTitle(scoreHistory.getRelatedQuestion() == null ?
+            null : scoreHistory.getRelatedQuestion().getTitle())
+        .createdAt(scoreHistory.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/example/qnacomunity/entity/ScoreHistory.java
+++ b/src/main/java/com/example/qnacomunity/entity/ScoreHistory.java
@@ -1,0 +1,47 @@
+package com.example.qnacomunity.entity;
+
+import com.example.qnacomunity.type.ScoreDescription;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScoreHistory {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Member member;
+
+  private int score;
+  private int previous;
+  private int remain;
+
+  @Enumerated(EnumType.STRING)
+  private ScoreDescription description;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Question relatedQuestion;
+
+  @CreationTimestamp
+  private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/example/qnacomunity/repository/ScoreHistoryRepository.java
+++ b/src/main/java/com/example/qnacomunity/repository/ScoreHistoryRepository.java
@@ -1,0 +1,14 @@
+package com.example.qnacomunity.repository;
+
+import com.example.qnacomunity.entity.ScoreHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScoreHistoryRepository extends JpaRepository<ScoreHistory, Long> {
+
+  Page<ScoreHistory> findAllByMember_Id(Long memberId, Pageable pageable);
+
+}

--- a/src/main/java/com/example/qnacomunity/type/ScoreDescription.java
+++ b/src/main/java/com/example/qnacomunity/type/ScoreDescription.java
@@ -1,0 +1,5 @@
+package com.example.qnacomunity.type;
+
+public enum ScoreDescription {
+  JOIN, QUESTION_MADE, QUESTION_CHANGE, QUESTION_DELETE, ANSWER_MADE, ANSWER_PICKED, PICK_PAYBACK
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- ScoreHistory 테이블 추가(스코어 변경 사항 기록)
- ScoreDescription enum 추가(스코어 변경 사유)
- ScoreLock 어노테이션 추가
- MemberScoreAspect(Aop), LockService(락 획득), MemberScoreService(스코어 변경) 클래스 추가

- 스코어/조회수 락 구조 변경  
  기존: 상위 메서드 -> Aop -> 락 획득(변경 실행)  
  변경: 상위 메서드 -> Aop -> 락 획득 -> transactional 메서드(변경 실행)  
  이유: 동시성 테스트 시 다른 트랜잭션 에서 변경한 내용을 읽어오지 못하는 상황 발생,  
   LockService 내부에 트랜잭션 메서드 삽입하여 락 해제 전 트랜잭션 커밋 되도록 변경

- MemberController: getScoreHistories(스코어 히스토리 확인) 메서드 추가
- MemberService: 회원가입 시 시작 스코어(50점) 제공 로직 추가
- QnaService: 질문 생성/변경/삭제, 답변 채택 시 스코어 변경 로직 추가

**TO-BE**

### 테스트
- [x] 테스트 코드
- [x] API 테스트 