### PR TITLE
feat: ElasticSearch 검색 기능 구현

### DIFF
--- a/src/main/java/com/example/qnacomunity/QnaComunityApplication.java
+++ b/src/main/java/com/example/qnacomunity/QnaComunityApplication.java
@@ -2,7 +2,9 @@ package com.example.qnacomunity;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class QnaComunityApplication {
 

--- a/src/main/java/com/example/qnacomunity/config/ElasticSearchConfig.java
+++ b/src/main/java/com/example/qnacomunity/config/ElasticSearchConfig.java
@@ -1,0 +1,71 @@
+package com.example.qnacomunity.config;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Slf4j
+@Configuration
+@EnableElasticsearchRepositories
+public class ElasticSearchConfig extends ElasticsearchConfiguration {
+
+  @Value("${spring.data.elasticsearch.url}")
+  private String host;
+
+  @Value("${spring.data.elasticsearch.username}")
+  private String username;
+
+  @Value("${spring.data.elasticsearch.password}")
+  private String password;
+
+  @Override
+  public ClientConfiguration clientConfiguration() {
+    return ClientConfiguration.builder()
+        .connectedTo(host)
+        .usingSsl(disableSslVerification(), allHostsValid())
+        .withBasicAuth(username, password)
+        .build();
+  }
+
+  public static SSLContext disableSslVerification() {
+    try {
+      TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
+        public X509Certificate[] getAcceptedIssuers() {
+          return null;
+        }
+
+        public void checkClientTrusted(X509Certificate[] certs, String authType) {
+        }
+
+        public void checkServerTrusted(X509Certificate[] certs, String authType) {
+        }
+      }};
+
+      SSLContext sc = SSLContext.getInstance("SSL");
+      sc.init(null, trustAllCerts, new java.security.SecureRandom());
+      HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+      return sc;
+
+    } catch (NoSuchAlgorithmException | KeyManagementException e) {
+      log.warn(e.getMessage());
+    }
+    return null;
+  }
+
+  public static HostnameVerifier allHostsValid() {
+    HostnameVerifier allHostsValid = (hostname, session) -> true;
+    HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+    return allHostsValid;
+  }
+}

--- a/src/main/java/com/example/qnacomunity/controller/SearchController.java
+++ b/src/main/java/com/example/qnacomunity/controller/SearchController.java
@@ -1,0 +1,48 @@
+package com.example.qnacomunity.controller;
+
+import com.example.qnacomunity.dto.form.SearchForm;
+import com.example.qnacomunity.service.ElasticSearchService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/search")
+@RestController
+@RequiredArgsConstructor
+public class SearchController {
+
+  private final ElasticSearchService elasticSearchService;
+
+  //제목 또는 내용 검색
+  @GetMapping("/word")
+  public ResponseEntity<?> searchWord(
+      @PageableDefault Pageable pageable,
+      @Valid @RequestBody SearchForm.WordSearchForm form
+  ) {
+
+    return ResponseEntity.ok(elasticSearchService.searchWord(pageable, form));
+  }
+
+  //키워드 검색
+  @GetMapping("/keyword")
+  public ResponseEntity<?> searchKeyword(
+      @PageableDefault Pageable pageable,
+      @Valid @RequestBody SearchForm.KeywordSearchForm form
+  ) {
+
+    return ResponseEntity.ok(elasticSearchService.searchKeyword(pageable, form));
+  }
+
+  @GetMapping("/related-questions/{questionId}")
+  public ResponseEntity<?> getRelatedQuestions(@PathVariable Long questionId) {
+
+    return ResponseEntity.ok(elasticSearchService.getRelatedQuestions(questionId));
+  }
+}

--- a/src/main/java/com/example/qnacomunity/dto/form/SearchForm.java
+++ b/src/main/java/com/example/qnacomunity/dto/form/SearchForm.java
@@ -1,0 +1,31 @@
+package com.example.qnacomunity.dto.form;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SearchForm {
+
+  @Getter
+  @Builder
+  public static class WordSearchForm {
+    @Size(min = 1, max = 20, message = "양식 오류: 검색어를 1~20자 사이로 입력해주세요.")
+    String word;
+
+    //최신순 = 1, 정확도순 = 0
+    int byLatest;
+
+    //제목만 = 1, 제목+내용 = 0
+    int byTitleOnly;
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class KeywordSearchForm {
+    @Size(min = 2, max = 20, message = "양식 오류: 키워드 검색어를 2~20자 사이로 입력해주세요.")
+    String keyword;
+  }
+}

--- a/src/main/java/com/example/qnacomunity/elasticsearch/ElasticSearchRepository.java
+++ b/src/main/java/com/example/qnacomunity/elasticsearch/ElasticSearchRepository.java
@@ -1,0 +1,8 @@
+package com.example.qnacomunity.elasticsearch;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ElasticSearchRepository extends ElasticsearchRepository<QuestionDocument, Long> {
+}

--- a/src/main/java/com/example/qnacomunity/elasticsearch/QuestionDocument.java
+++ b/src/main/java/com/example/qnacomunity/elasticsearch/QuestionDocument.java
@@ -1,0 +1,38 @@
+package com.example.qnacomunity.elasticsearch;
+
+import com.example.qnacomunity.entity.Question;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+@Getter
+@Setter
+@Builder
+@Setting(settingPath = "/elasticsearch/settings/settings.json", replicas = 0)
+@Mapping(mappingPath = "/elasticsearch/mappings/mappings.json")
+@Document(indexName = "questions")
+public class QuestionDocument {
+
+  @Id
+  private Long id;
+
+  private String title;
+
+  private String content;
+
+  private String keywords;
+
+  public static QuestionDocument from(Question question) {
+
+    return QuestionDocument.builder()
+        .id(question.getId())
+        .title(question.getTitle())
+        .content(question.getContent())
+        .keywords(String.join(" ", question.getKeywords()))
+        .build();
+  }
+}

--- a/src/main/java/com/example/qnacomunity/entity/Failure.java
+++ b/src/main/java/com/example/qnacomunity/entity/Failure.java
@@ -1,0 +1,39 @@
+package com.example.qnacomunity.entity;
+
+import com.example.qnacomunity.type.FailureType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Failure {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Question question;
+
+  @Enumerated(EnumType.STRING)
+  private FailureType failureType;
+
+  @CreationTimestamp
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/qnacomunity/repository/FailureRepository.java
+++ b/src/main/java/com/example/qnacomunity/repository/FailureRepository.java
@@ -1,0 +1,10 @@
+package com.example.qnacomunity.repository;
+
+import com.example.qnacomunity.entity.Failure;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FailureRepository extends JpaRepository<Failure, Long> {
+
+}

--- a/src/main/java/com/example/qnacomunity/scheduler/Scheduler.java
+++ b/src/main/java/com/example/qnacomunity/scheduler/Scheduler.java
@@ -1,0 +1,54 @@
+package com.example.qnacomunity.scheduler;
+
+import com.example.qnacomunity.service.ElasticSearchService;
+import com.example.qnacomunity.entity.Failure;
+import com.example.qnacomunity.entity.Question;
+import com.example.qnacomunity.repository.FailureRepository;
+import com.example.qnacomunity.type.FailureType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class Scheduler {
+
+  private final FailureRepository failureRepository;
+  private final ElasticSearchService elasticSearchService;
+
+  //매 시간 마다 실패 내역 확인후 재시도
+  @Scheduled(cron = "${spring.scheduler.time}")
+  @Transactional
+  public void failurePatch() {
+    List<Failure> failures = failureRepository.findAll();
+
+    for (Failure failure : failures) {
+
+      Question question = failure.getQuestion();
+
+      if (failure.getFailureType() == FailureType.SAVE_FAIL) {
+        try {
+          elasticSearchService.save(question);
+          failureRepository.delete(failure);
+          log.info("ES 저장 성공");
+        } catch (Exception e) {
+          log.error(e.getMessage());
+        }
+      }
+
+      else if (failure.getFailureType() == FailureType.DELETE_FAIL) {
+        try {
+          elasticSearchService.delete(question.getId());
+          failureRepository.delete(failure);
+          log.info("ES 삭제 성공");
+        } catch (Exception e) {
+          log.error(e.getMessage());
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/example/qnacomunity/service/ElasticSearchService.java
+++ b/src/main/java/com/example/qnacomunity/service/ElasticSearchService.java
@@ -1,0 +1,172 @@
+package com.example.qnacomunity.service;
+
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import com.example.qnacomunity.dto.form.SearchForm;
+import com.example.qnacomunity.dto.response.QuestionResponse;
+import com.example.qnacomunity.elasticsearch.ElasticSearchRepository;
+import com.example.qnacomunity.elasticsearch.QuestionDocument;
+import com.example.qnacomunity.entity.Question;
+import com.example.qnacomunity.exception.CustomException;
+import com.example.qnacomunity.exception.ErrorCode;
+import com.example.qnacomunity.repository.QuestionRepository;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ElasticSearchService {
+
+  private final QuestionRepository questionRepository;
+  private final ElasticsearchOperations elasticsearchOperations;
+  private final ElasticSearchRepository elasticSearchRepository;
+
+  @Transactional
+  public void save(Question question) {
+    QuestionDocument questionDocument = QuestionDocument.from(question);
+    elasticSearchRepository.save(questionDocument);
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    elasticSearchRepository.deleteById(id);
+  }
+
+  @Transactional
+  public List<QuestionResponse> searchWord(Pageable pageable, SearchForm.WordSearchForm form) {
+
+    String word = form.getWord().toLowerCase().replace("  ", " ").trim();
+    NativeQuery nativeQuery;
+
+    //제목만 검색
+    if (form.getByTitleOnly() == 1) {
+
+      Query query = QueryBuilders.match()
+          .query(word)
+          .field("title")
+          .build()._toQuery();
+
+      nativeQuery = new NativeQueryBuilder()
+          .withQuery(query)
+          .build();
+    }
+
+    //제목+내용 검색
+    else {
+
+      Query matchTitle = QueryBuilders.match()
+          .query(word)
+          .field("title")
+          .build()._toQuery();
+
+      Query matchContent = QueryBuilders.match()
+          .query(word)
+          .field("content")
+          .build()._toQuery();
+
+      Query query = QueryBuilders.bool()
+          .should(matchTitle, matchContent)
+          .build()._toQuery();
+
+      nativeQuery = new NativeQueryBuilder()
+          .withQuery(query)
+          .build();
+    }
+
+    SearchHits<QuestionDocument> searchHits =
+        elasticsearchOperations.search(nativeQuery, QuestionDocument.class);
+
+    //최신순
+    if (form.getByLatest() == 1) {
+      return searchHits.get()
+          .map(s -> QuestionResponse.from(fromDocument(s.getContent())))
+          .sorted(Comparator.comparing(QuestionResponse::getCreatedAt, Comparator.reverseOrder()))
+          .skip((long) pageable.getPageNumber() * pageable.getPageSize())
+          .limit(pageable.getPageSize())
+          .toList();
+    }
+
+    //정확도순
+    else {
+      return searchHits.get()
+          .map(s -> QuestionResponse.from(fromDocument(s.getContent())))
+          .skip((long) pageable.getPageNumber() * pageable.getPageSize())
+          .limit(pageable.getPageSize())
+          .toList();
+    }
+  }
+
+  @Transactional
+  public List<QuestionResponse> searchKeyword(Pageable pageable, SearchForm.KeywordSearchForm form) {
+
+    String keyword = form.getKeyword().toLowerCase()
+        .replace(" ", "")
+        .replace("##", "#")
+        .replace("#", " ")
+        .trim();
+
+    //키워드 모두 일치하는 글 조회
+    Query matchQuery = QueryBuilders.match()
+        .query(keyword)
+        .field("keywords")
+        .operator(Operator.And)
+        .build()._toQuery();
+
+    NativeQuery nativeQuery = new NativeQueryBuilder()
+        .withQuery(matchQuery)
+        .build();
+
+    SearchHits<QuestionDocument> searchHits =
+        elasticsearchOperations.search(nativeQuery, QuestionDocument.class);
+
+    //최신순 정렬
+    return searchHits.get()
+        .map(s -> QuestionResponse.from(fromDocument(s.getContent())))
+        .sorted(Comparator.comparing(QuestionResponse::getCreatedAt, Comparator.reverseOrder()))
+        .skip((long) pageable.getPageNumber() * pageable.getPageSize())
+        .limit(pageable.getPageSize())
+        .toList();
+  }
+
+  @Transactional
+  public List<QuestionResponse> getRelatedQuestions(Long questionId) {
+
+    Question question = questionRepository.findById(questionId)
+        .orElseThrow(() -> new CustomException(ErrorCode.Q_NOT_FOUND));
+
+    String keyword = String.join(" ", question.getKeywords());
+
+    //키워드가 하나 이상 일치하는 글 검색
+    Query matchQuery = QueryBuilders.match()
+        .query(keyword)
+        .field("keywords")
+        .build()._toQuery();
+
+    NativeQuery nativeQuery = new NativeQueryBuilder()
+        .withQuery(matchQuery)
+        .build();
+
+    SearchHits<QuestionDocument> searchHits =
+        elasticsearchOperations.search(nativeQuery, QuestionDocument.class);
+
+    return searchHits.get()
+        .map(s -> QuestionResponse.from(fromDocument(s.getContent())))
+        .filter(q -> !q.getId().equals(questionId)) //연관글에서 자기 자신 제거
+        .limit(3)
+        .toList();
+  }
+
+  private Question fromDocument(QuestionDocument document) {
+    return questionRepository.findById(document.getId()).orElse(null);
+  }
+}

--- a/src/main/java/com/example/qnacomunity/type/FailureType.java
+++ b/src/main/java/com/example/qnacomunity/type/FailureType.java
@@ -1,0 +1,5 @@
+package com.example.qnacomunity.type;
+
+public enum FailureType {
+  SAVE_FAIL, DELETE_FAIL
+}

--- a/src/main/resources/elasticsearch/mappings/mappings.json
+++ b/src/main/resources/elasticsearch/mappings/mappings.json
@@ -1,0 +1,19 @@
+{
+  "properties": {
+
+    "title": {
+      "type": "text",
+      "analyzer": "korean"
+    },
+
+    "content": {
+      "type": "text",
+      "analyzer": "korean"
+    },
+
+    "keywords": {
+      "type": "text"
+    }
+  }
+
+}

--- a/src/main/resources/elasticsearch/settings/settings.json
+++ b/src/main/resources/elasticsearch/settings/settings.json
@@ -1,0 +1,9 @@
+{
+  "analysis": {
+    "analyzer": {
+      "korean": {
+        "type": "nori"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 제목/내용 검색(searchWord), 키워드 검색(searchKeyword) 구현(정확도/최신순)
- 연관글 기능 구현(키워드 일치순)
- ElasticSearch 연동 실패시 Failure 테이블에 실패 내역 저장
- Scheduler 통해 실패 내역 확인, 재시도

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 