### PR TITLE
feat: 멤버 랭킹 기능 구현(DB 연동 방식)

### DIFF
--- a/src/main/java/com/example/qnacomunity/controller/RankController.java
+++ b/src/main/java/com/example/qnacomunity/controller/RankController.java
@@ -1,8 +1,7 @@
 package com.example.qnacomunity.controller;
 
-import com.example.qnacomunity.dto.response.Rank;
 import com.example.qnacomunity.service.RankService;
-import com.example.qnacomunity.type.RankType;
+import com.example.qnacomunity.service.RankService.RankedMember;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,12 +17,7 @@ public class RankController {
   private final RankService rankService;
 
   @GetMapping("/member")
-  public ResponseEntity<List<Rank>> getMemberRank() {
-    return ResponseEntity.ok(rankService.getRank(RankType.MEMBER));
-  }
-
-  @GetMapping("/keyword")
-  public ResponseEntity<List<Rank>> getKeywordRank() {
-    return ResponseEntity.ok(rankService.getRank(RankType.KEYWORD));
+  public ResponseEntity<List<RankedMember>> getMemberRank() {
+    return ResponseEntity.ok(rankService.getMemberRank());
   }
 }

--- a/src/main/java/com/example/qnacomunity/exception/ErrorCode.java
+++ b/src/main/java/com/example/qnacomunity/exception/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode {
   GRADE_EXIST("이름이나 최소 스코어가 동일한 등급이 있습니다."),
   GRADE_NOT_FOUND("등급을 찾을수 없습니다."),
   SCORE_NOT_ENOUGH("가지고 있는 스코어보다 보상을 많이 걸 수 없습니다."),
+  RANK_NOT_FOUND("랭킹 정보 확인 불가"),
+  RANK_UPDATE_FAIL("랭킹 업데이트 실패"),
   ACQUIRE_LOCK_FAIL("락 획득 실패"),
   FAILURE_TYPE_ERROR("연동 실패 타입 확인 불가");
 

--- a/src/main/java/com/example/qnacomunity/repository/MemberRepository.java
+++ b/src/main/java/com/example/qnacomunity/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.example.qnacomunity.repository;
 
 
 import com.example.qnacomunity.entity.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,5 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByLoginId(String loginId);
+
+  List<Member> findFirst10ByOrderByScoreDesc();
 
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 레디스 서버에 현재의 멤버 랭킹, 랭킹에 들기 위한 최소 스코어 저장
- 멤버 스코어 변화시 변경전이나 변경후 스코어가 최소 스코어보다 크면 DB로부터 랭킹 업데이트
- 위 상황에 해당되지 않으면 랭킹 업데이트 없이 레디스 랭킹 값 반환

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 