### PR TITLE
refactor: 등급 기능 수정

### DIFF
--- a/src/main/java/com/example/qnacomunity/QnaComunityApplication.java
+++ b/src/main/java/com/example/qnacomunity/QnaComunityApplication.java
@@ -2,8 +2,10 @@ package com.example.qnacomunity;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableCaching
 @EnableScheduling
 @SpringBootApplication
 public class QnaComunityApplication {

--- a/src/main/java/com/example/qnacomunity/config/RedisConfig.java
+++ b/src/main/java/com/example/qnacomunity/config/RedisConfig.java
@@ -4,12 +4,17 @@ import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -36,6 +41,20 @@ public class RedisConfig {
     redisTemplate.setKeySerializer(new StringRedisSerializer());
     redisTemplate.setValueSerializer(new StringRedisSerializer());
     return redisTemplate;
+  }
+
+  @Bean
+  public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+    RedisCacheConfiguration conf = RedisCacheConfiguration.defaultCacheConfig()
+        .serializeKeysWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+        .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+            new GenericJackson2JsonRedisSerializer()));
+
+    return RedisCacheManager.RedisCacheManagerBuilder
+        .fromConnectionFactory(redisConnectionFactory)
+        .cacheDefaults(conf)
+        .build();
   }
 
   @Bean

--- a/src/main/java/com/example/qnacomunity/controller/GradeController.java
+++ b/src/main/java/com/example/qnacomunity/controller/GradeController.java
@@ -63,10 +63,10 @@ public class GradeController {
   }
 
   @GetMapping("/my-grade")
-  public ResponseEntity<GradeResponse> getMyGrade(
+  public ResponseEntity<String> getMyGrade(
       @AuthenticationPrincipal CustomUserDetail userDetail
   ) {
 
-    return ResponseEntity.ok(gradeService.getMyGrades(userDetail.getMemberResponse()));
+    return ResponseEntity.ok(gradeService.getMyGrades(userDetail.getMemberResponse().getScore()));
   }
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- GradeService: updateGrade() 중복 체크시 gradeRepository 한번만 접근하도록 변경
- GradeService: getMyGrades() 해당되는 등급이 없으면 null 반환
- 스코어에 따른 등급 반환시 Redis Cache 사용
- 등급 생성,수정,삭제 시 Cache 초기화

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 